### PR TITLE
Add ARM64 support for Visual Studio 2022

### DIFF
--- a/src/VSPackage/source.extension.vsixmanifest
+++ b/src/VSPackage/source.extension.vsixmanifest
@@ -23,6 +23,10 @@
                             Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community"
+                            Version="[17.0, 18.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP"


### PR DESCRIPTION
This  is **100% UNTESTED** as I don't have ARM64 hardware